### PR TITLE
Markdown/HTML-Hinweise

### DIFF
--- a/pages/oda-generic.md
+++ b/pages/oda-generic.md
@@ -104,7 +104,7 @@ Empfohlen ist:
 - Der Datenendpunkt heißt kanonisch `apiurl` und die Datensatzseite `urlDaten`; parallele Legacy-Schreibweisen werden nicht neu eingeführt.
 - `format.typ` verwendet für ODAS-v1 nur `string`, `url`, `dropdown`, `markdown` und `image`.
 
-Felder mit `format.typ: "markdown"` (z.B. `beschreibung`, `kontakt`, `impressum`, `datenschutz`) werden in Markdown verfasst; ODAS wandelt das Markdown vor der Auslieferung der Konfiguration in HTML um, das die Vorlage unverändert rendert. Bestehende Konfigurationen enthalten in diesen Feldern teilweise noch direktes HTML. Das bleibt während der Übergangsphase gültig. Details stehen in der [ODA-Spezifikation]({{ site.baseurl }}/open-data-app-spezifikation).
+Felder mit `format.typ: "markdown"` (z.B. `beschreibung`, `kontakt`, `impressum`, `datenschutz`) werden in Markdown verfasst; ODAS wandelt das Markdown vor der Auslieferung der Konfiguration in HTML um, das die Vorlage unverändert rendert. Frühere Paketstände enthielten in diesen Feldern direktes HTML als Übergangsform. Das ist nicht mehr zulässig; bestehende Apps wurden auf Markdown migriert. Lokales `odas-config/config.json` bleibt als gerendertes HTML arbeitsfähig (darf im jeweiligen App-Repo versioniert sein und wird bei inhaltlicher Änderung mit committet). Details stehen in der [ODA-Spezifikation]({{ site.baseurl }}/open-data-app-spezifikation).
 
 ## Lokale Entwicklung
 

--- a/pages/oda-generic.md
+++ b/pages/oda-generic.md
@@ -104,7 +104,7 @@ Empfohlen ist:
 - Der Datenendpunkt heißt kanonisch `apiurl` und die Datensatzseite `urlDaten`; parallele Legacy-Schreibweisen werden nicht neu eingeführt.
 - `format.typ` verwendet für ODAS-v1 nur `string`, `url`, `dropdown`, `markdown` und `image`.
 
-Felder mit `format.typ: "markdown"` (z.B. `beschreibung`, `kontakt`, `impressum`, `datenschutz`) werden in Markdown verfasst; ODAS wandelt das Markdown vor der Auslieferung der Konfiguration in HTML um, das die Vorlage unverändert rendert. Frühere Paketstände enthielten in diesen Feldern direktes HTML als Übergangsform. Das ist nicht mehr zulässig; bestehende Apps wurden auf Markdown migriert. Lokales `odas-config/config.json` bleibt als gerendertes HTML arbeitsfähig (darf im jeweiligen App-Repo versioniert sein und wird bei inhaltlicher Änderung mit committet). Details stehen in der [ODA-Spezifikation]({{ site.baseurl }}/open-data-app-spezifikation).
+Felder mit `format.typ: "markdown"` (z.B. `beschreibung`, `kontakt`, `impressum`, `datenschutz`) werden in Markdown verfasst; ODAS wandelt das Markdown vor der Auslieferung der Konfiguration in HTML um, das die Vorlage unverändert rendert. Im lokalen `odas-config/config.json` stehen diese Inhalte als HTML. Details stehen in der [ODA-Spezifikation]({{ site.baseurl }}/open-data-app-spezifikation).
 
 ## Lokale Entwicklung
 

--- a/pages/open-data-app-spezifikation.md
+++ b/pages/open-data-app-spezifikation.md
@@ -315,7 +315,7 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` Ã
       },
       "default": [
         "_multiline_",
-        "Bei Fragen zur App wenden Sie sich bitte an den im Impressum genannten Anbieter."
+        "Bei Fragen zur App wenden Sie sich bitte an die in unserem Impressum genannten Kontaktdaten."
       ],
       "erforderlich": "ja"
     },

--- a/pages/open-data-app-spezifikation.md
+++ b/pages/open-data-app-spezifikation.md
@@ -159,7 +159,7 @@ Dieser Wert wird im ODAS interpretiert als:
 
 `format.typ: "markdown"` ist der ODAS-v1-Feldtyp für Rich Text. Felder dieses Typs werden in Markdown verfasst: Überschriften mit `##`, Listen mit `-`, Links mit `[Text](URL)`. ODAS wandelt das Markdown vor der Auslieferung der Konfiguration an die App in HTML um; die App rendert das Ergebnis unverändert (z.B. per `innerHTML`). Portalbetreiber können Felder wie Impressum, Kontakt oder Beschreibung dadurch ohne HTML-Kenntnisse pflegen.
 
-**Hinweis zur Übergangsphase:** Bestehende Apps und Konfigurationen enthalten in Markdown-Feldern teilweise direkt HTML (z.B. `<h2>`, `<p>`, `<ul>`). Das bleibt während der Übergangsphase gültig; für neue und überarbeitete Inhalte ist Markdown der Standard. Das Beispiel-`app-package.json` weiter unten zeigt den aktuellen Stand der Vorlage `oda-generic` und enthält deshalb noch HTML-Defaults.
+Historisch enthielten einige Paket-Markdown-Felder direktes HTML. Das war eine Übergangsform und ist nicht mehr zulässig. Für neue und überarbeitete Inhalte ist Markdown der Standard; bestehende Apps wurden auf Markdown migriert. Der Linter weist HTML-Tags in Paket-Markdown-Feldern zurück (fokussierter Detektor, keine False-Positives für Markdown-Autolinks), während lokales `odas-config/config.json` als gerendertes HTML weiterhin akzeptiert wird. `odas-config/config.json` ist lokale Runtime-Fixture, darf im jeweiligen App-Repo versioniert sein und wird bei jeder inhaltlichen Spiegel-Änderung mit committet.
 
 Statische Beschreibungstexte bleiben im bestehenden Feld `beschreibung`; dafür werden keine zusätzlichen Config-Keys angelegt. Die Datenquellenbeschreibung verlinkt, soweit Werte vorhanden sind, vom Open Data Portal über die Datensatzseite bis zur tatsächlich verwendeten Ressource oder API.
 
@@ -315,7 +315,7 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` �
       },
       "default": [
         "_multiline_",
-        "<p>Bei Fragen zur App wenden Sie sich bitte an die im Open Data Portal hinterlegte Kontaktstelle.</p>"
+        "Bei Fragen zur App wenden Sie sich bitte an die im Open Data Portal hinterlegte Kontaktstelle."
       ],
       "erforderlich": "ja"
     },
@@ -327,10 +327,11 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` �
       },
       "default": [
         "_multiline_",
-        "<h2>Ueber diese Vorlage</h2>",
-        "<p>Diese App zeigt die wirksame Instanz-Konfiguration.</p>",
-        "<h2>Datenquelle</h2>",
-        "<p>Die Generic-App laedt absichtlich keinen Fachdatenbestand.</p>"
+        "## Ueber diese Vorlage",
+        "Diese App zeigt die wirksame Instanz-Konfiguration.",
+        "",
+        "## Datenquelle",
+        "Die Generic-App laedt absichtlich keinen Fachdatenbestand."
       ],
       "erforderlich": "ja"
     },
@@ -342,8 +343,8 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` �
       },
       "default": [
         "_multiline_",
-        "<h2>Anbieter</h2>",
-        "<p>{{{odp.anbieter.orgName}}}<br>{{odp.anbieter.strasse}}<br>{{odp.anbieter.plzort}}</p>"
+        "## Anbieter",
+        "{{{odp.anbieter.orgName}}}, {{{odp.anbieter.strasse}}}, {{{odp.anbieter.plzort}}}"
       ],
       "erforderlich": "ja"
     },
@@ -355,7 +356,7 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` �
       },
       "default": [
         "_multiline_",
-        "<p>Massgeblich sind die Datenschutzangaben des jeweiligen Portalbetreibers.</p>"
+        "Massgeblich sind die Datenschutzangaben des jeweiligen Portalbetreibers."
       ],
       "erforderlich": "ja"
     },
@@ -488,7 +489,7 @@ Die Datenquellenbeschreibung in `beschreibung` verlinkt dreistufig: Open Data Po
 }
 ```
 
-Die `markdown`-Defaults sind hier bereits in Markdown verfasst, konform zum oben beschriebenen Standard. Bestands-Apps verwenden in diesen Feldern noch HTML.
+Die `markdown`-Defaults sind in Markdown verfasst; HTML-Tags in diesen Paketfeldern sind nicht zulässig. Lokales `odas-config/config.json` bleibt als gerendertes HTML erhalten und wird semantisch gespiegelt.
 
 ## Ondics-Standard
 

--- a/pages/open-data-app-spezifikation.md
+++ b/pages/open-data-app-spezifikation.md
@@ -159,7 +159,7 @@ Dieser Wert wird im ODAS interpretiert als:
 
 `format.typ: "markdown"` ist der ODAS-v1-Feldtyp für Rich Text. Felder dieses Typs werden in Markdown verfasst: Überschriften mit `##`, Listen mit `-`, Links mit `[Text](URL)`. ODAS wandelt das Markdown vor der Auslieferung der Konfiguration an die App in HTML um; die App rendert das Ergebnis unverändert (z.B. per `innerHTML`). Portalbetreiber können Felder wie Impressum, Kontakt oder Beschreibung dadurch ohne HTML-Kenntnisse pflegen.
 
-Historisch enthielten einige Paket-Markdown-Felder direktes HTML. Das war eine Übergangsform und ist nicht mehr zulässig. Für neue und überarbeitete Inhalte ist Markdown der Standard; bestehende Apps wurden auf Markdown migriert. Der Linter weist HTML-Tags in Paket-Markdown-Feldern zurück (fokussierter Detektor, keine False-Positives für Markdown-Autolinks), während lokales `odas-config/config.json` als gerendertes HTML weiterhin akzeptiert wird. `odas-config/config.json` ist lokale Runtime-Fixture, darf im jeweiligen App-Repo versioniert sein und wird bei jeder inhaltlichen Spiegel-Änderung mit committet.
+In der `app-package.json` werden diese Felder in Markdown verfasst; im lokalen `odas-config/config.json` steht der bereits gerenderte HTML-Stand.
 
 Statische Beschreibungstexte bleiben im bestehenden Feld `beschreibung`; dafür werden keine zusätzlichen Config-Keys angelegt. Die Datenquellenbeschreibung verlinkt, soweit Werte vorhanden sind, vom Open Data Portal über die Datensatzseite bis zur tatsächlich verwendeten Ressource oder API.
 
@@ -489,7 +489,7 @@ Die Datenquellenbeschreibung in `beschreibung` verlinkt dreistufig: Open Data Po
 }
 ```
 
-Die `markdown`-Defaults sind in Markdown verfasst; HTML-Tags in diesen Paketfeldern sind nicht zulässig. Lokales `odas-config/config.json` bleibt als gerendertes HTML erhalten und wird semantisch gespiegelt.
+Die `markdown`-Defaults sind in Markdown verfasst.
 
 ## Ondics-Standard
 

--- a/pages/open-data-app-spezifikation.md
+++ b/pages/open-data-app-spezifikation.md
@@ -315,7 +315,7 @@ Die Paketversion muss mit dem obersten versionierten Eintrag in `CHANGELOG.md` Ã
       },
       "default": [
         "_multiline_",
-        "Bei Fragen zur App wenden Sie sich bitte an die im Open Data Portal hinterlegte Kontaktstelle."
+        "Bei Fragen zur App wenden Sie sich bitte an den im Impressum genannten Anbieter."
       ],
       "erforderlich": "ja"
     },


### PR DESCRIPTION
Doku beschreibt kurz: Markdown in `app-package.json`, HTML in `odas-config/config.json`.